### PR TITLE
Added library for firebase-database

### DIFF
--- a/firebase_login_sample/android/gradle.properties
+++ b/firebase_login_sample/android/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-
+android.useAndroidX=true
+android.enableJetifier=true

--- a/firebase_login_sample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/firebase_login_sample/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/firebase_login_sample/pubspec.lock
+++ b/firebase_login_sample/pubspec.lock
@@ -36,6 +36,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
+  firebase_analytics:
+    dependency: "direct main"
+    description:
+      name: firebase_analytics
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.2"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -50,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.0+9"
+  firebase_database:
+    dependency: "direct main"
+    description:
+      name: firebase_database
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.7"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/firebase_login_sample/pubspec.yaml
+++ b/firebase_login_sample/pubspec.yaml
@@ -20,7 +20,9 @@ dependencies:
   flutter:
     sdk: flutter
   firebase_auth: ^0.14.0+5
-  # firebase_database: ^3.0.7
+  firebase_analytics: ^5.0.2
+
+  firebase_database: ^3.0.7
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Note:
modified
```android/gradle/wrapper/gradle-wrapper.properties```
added 
```distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip```

modified
```android/gradle.properties```
added
```android.useAndroidX=true
android.enableJetifier=true```

Firebase SDKs no longer use android support libraries. See 
https://firebase.google.com/docs/android/setup#available-libraries

